### PR TITLE
add DELETE client calls for databases, users and pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 dist
 *.egg-info
 /docs/build/
+.python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "douze"
-version = "0.2.0"
+version = "0.1.5"
 description = "A DigitalOcean API client to help with 12-factors apps"
 authors = ["Rémy Sanchez <remy.sanchez@hyperthese.net>"]
 license = "WTFPL"
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-typefit = "^0.5.0"
+typefit = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "douze"
-version = "0.1.5"
+version = "0.2.0"
 description = "A DigitalOcean API client to help with 12-factors apps"
 authors = ["Rémy Sanchez <remy.sanchez@hyperthese.net>"]
 license = "WTFPL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-typefit = "^0.4.0"
+typefit = "^0.5.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/src/douze/api.py
+++ b/src/douze/api.py
@@ -184,6 +184,12 @@ class DoApi(api.SyncClient):
         Creates a database within a cluster
         """
 
+    @api.delete("databases/{cluster_id}/dbs/{database_name}")
+    def db_database_delete(self, cluster_id: Text, database_name: Text) -> None:
+        """
+        Deletes the specified database within the cluster
+        """
+
     @api.get("databases/{cluster_id}/firewall", hint="rules")
     def db_firewall_list(self, cluster_id: Text) -> List[DatabaseFirewallRule]:
         """
@@ -214,6 +220,12 @@ class DoApi(api.SyncClient):
         Creates a user within a cluster
         """
 
+    @api.delete("databases/{cluster_id}/users/{user_name}")
+    def db_user_delete(self, cluster_id: Text, user_name: Text) -> None:
+        """
+        Deletes a user within a cluster
+        """
+
     @api.get("databases/{cluster_id}/pools", hint="pools")
     def db_pool_list(self, cluster_id: Text) -> List[DatabaseConnectionPool]:
         """
@@ -226,6 +238,12 @@ class DoApi(api.SyncClient):
     ) -> DatabaseConnectionPool:
         """
         Creates a connection pool for that cluster
+        """
+
+    @api.delete("databases/{cluster_id}/pools/{pool_name}")
+    def db_pool_delete(self, cluster_id: Text, pool_name: Text) -> None:
+        """
+        Deletes a connection pool for that cluster
         """
 
     @api.get("database/{cluster_id}/pools/{pool_name}", hint="pool")

--- a/src/douze/idem_api.py
+++ b/src/douze/idem_api.py
@@ -498,13 +498,13 @@ class DoIdemApi:
                 self.api.db_user_delete(cluster.id, user_name=user_name)
 
         pool = None
+        effective_pool_name = f"user_{user_name}"
 
         for candidate in self.api.db_pool_list(cluster.id):
-            if candidate.name == f"user_{user_name}":
+            if candidate.name == effective_pool_name:
                 pool = candidate
                 break
 
-        effective_pool_name = f"user_{user_name}"
         if not pool and pool_size:
             if present:
                 changed = True


### PR DESCRIPTION
delete calls reflected in IdemApi, adding the possibility to add
`state: absent` to the ansible modules `douze_psql_database` and
`douze_psql_user`

Depends on missing decorator in: https://github.com/Xowap/typefit/pull/36